### PR TITLE
Fix code scanning alert no. 2: Creating an ASP.NET debug binary may reveal sensitive information

### DIFF
--- a/DynamicTester/bin/DynamicTesting.dll.config
+++ b/DynamicTester/bin/DynamicTesting.dll.config
@@ -2,7 +2,7 @@
 <configuration>
 
 	<system.web>
-		<compilation debug="true" targetFramework="4.0" />
+		<compilation debug="false" targetFramework="4.0" />
 	</system.web>
 	<system.serviceModel>
 		<bindings>


### PR DESCRIPTION
Fixes [https://github.com/nataliekmoes/DynamicWebSvcTester/security/code-scanning/2](https://github.com/nataliekmoes/DynamicWebSvcTester/security/code-scanning/2)

To fix the problem, the `debug` flag should be set to `false` or removed entirely from the `Web.config` file. This change will prevent the application from exposing sensitive debugging information and improve performance in a production environment.

- Locate the `Web.config` file in the `DynamicTester/bin/DynamicTesting.dll.config` path.
- Find the line containing `<compilation debug="true" targetFramework="4.0" />`.
- Change the `debug` attribute to `false` or remove the `debug` attribute entirely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
